### PR TITLE
feat(optionTimeout) : added timeout option for init

### DIFF
--- a/PouchyStore.js
+++ b/PouchyStore.js
@@ -35,6 +35,9 @@ export default class PouchyStore {
     if (!('optionsRemote' in this)) {
       this.optionsRemote = {};
     }
+    if(!('optionsTimout' in this)){
+      this.timeOut = 5;
+    }
     this.initializeProperties();
   }
 
@@ -62,7 +65,9 @@ export default class PouchyStore {
 
   async initialize() {
     if (this.isInitialized) return;
-
+    if(this.optionsTimeout){
+      this.timeOut = this.optionsTimeout;
+    }
     if (!this.name) {
       throw new Error('store must have name');
     }
@@ -99,7 +104,7 @@ export default class PouchyStore {
     if (this.isUseRemote) {
       // sync data local-remote
       try {
-        await checkInternet(this.urlRemote);
+        await checkInternet(this.urlRemote, this.timeOut);
         await this.dbLocal.replicate.from(this.dbRemote, {
           batch_size: 1000,
           batches_limit: 2,
@@ -299,7 +304,7 @@ export default class PouchyStore {
   async upload() {
     if (!this.isUseRemote) return;
 
-    await checkInternet(this.urlRemote);
+    await checkInternet(this.urlRemote, this.timeOut);
 
     await this.dbLocal.replicate.to(this.dbRemote);
     const ids = Object.keys(this.dataMeta.unuploadeds);

--- a/libs/checkInternet.js
+++ b/libs/checkInternet.js
@@ -1,6 +1,4 @@
-const TIMEOUT_INTERNET_CHECK = 5; // seconds
-
-const checkInternet = (url) => {
+const checkInternet = (url, TIMEOUT_INTERNET_CHECK) => {
   return new Promise((resolve, reject) => {
     const timer = setTimeout(() => {
       reject(new Error('No internet connection'));


### PR DESCRIPTION
- added timeout option inside init
usage inside store class
```
get optionsTimeout() {
    return 2
  }
```
conditional timeouts for flexibility
for example, my app is used in areas with unstable internet, sync function will need to wait `checkInternet` function to resolve because there is internet but not a stable one, the usability of my app drops, if I set my timeout to 2 seconds my app would have better usability