### PR TITLE
fix(PouchyStore): handle upload error

### DIFF
--- a/PouchyStore.js
+++ b/PouchyStore.js
@@ -264,7 +264,15 @@ class PouchyStore {
 
   async upload() {
     await checkInternet(this.urlRemote);
-    await this.dbLocal.replicate.to(this.dbRemote);
+    await new Promise((resolve, reject) => {
+      this.dbLocal.replicate.to(this.dbRemote, {
+        live: false,
+      }).on('complete', (info) => {
+        resolve(info);
+      }).on('error', (err) => {
+        reject(err);
+      });
+    });
 
     this.dataMeta.tsUpload = new Date().toJSON();
     this.persistMeta();


### PR DESCRIPTION
Current code doesn't catch error when uploading to remote. This PR use event listener https://pouchdb.com/api.html#replication to receive the error and throw it as exception.